### PR TITLE
Fix log manager purge order by using API order

### DIFF
--- a/plugins/logmanager.py
+++ b/plugins/logmanager.py
@@ -77,20 +77,23 @@ class LogManager(PluginLoader):
 
                 if not delete_immediately:
                     local_request_count = 0
-                    # sort posts by id
-                    posts_to_delete = sorted(posts_to_delete)
-                    # make sure they are unique
-                    posts_to_delete = list(dict.fromkeys(posts_to_delete))
+                    # Remove duplicates while preserving order
+                    seen = set()
+                    unique_posts = []
+                    for p in posts_to_delete:
+                        if p not in seen:
+                            seen.add(p)
+                            unique_posts.append(p)
+                    posts_to_delete = unique_posts
                     delete_count = len(posts_to_delete)
                     max_log_every_n = 5000
-                    log_every_n = min(max_log_every_n,int(delete_count // 10))
-                    # keep the last 100
-                    posts_to_delete = posts_to_delete[:-lines_to_keep]
+                    log_every_n = min(max_log_every_n, int(delete_count // 10) or max_log_every_n)
+                    # Keep the first 'lines_to_keep' posts (most recent), and delete the rest.
+                    posts_to_delete = posts_to_delete[lines_to_keep:]
                     for post_id in posts_to_delete:
                         self.driver.posts.delete_post(post_id)
                         if local_request_count % log_every_n == 0:
-                            # log every 500 requests
-                            self.helper.console(f"Deleted {local_request_count}/{delete_count} made {request_count} (max: {max_requests}) requests.")
+                            self.helper.console(f"Deleted {local_request_count}/{delete_count} (made {request_count} requests, max: {max_requests}).")
                         request_count += 1
                         local_request_count += 1
                 return posts_to_delete, request_count


### PR DESCRIPTION
This PR fixes the log manager purge order by using the API-provided order instead of sorting by post ID, ensuring that the most recent posts are retained.